### PR TITLE
can only add clippings to cart up to the number available

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -39,3 +39,8 @@
   margin-top: 24px;
   margin-left: 100px;
 }
+
+.typed-js {
+  margin-top: 1rem;
+  height: 35px;
+}

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -24,6 +24,7 @@ class ChargesController < ApplicationController
     @charge.add_products(current_user)
     destroy_cart
     redirect_to thanks_path
+    reduce_stock
   rescue Stripe::CardError => e
     flash[:error] = e.message
     redirect_to new_charge_path
@@ -38,6 +39,13 @@ class ChargesController < ApplicationController
 
   def amount_to_be_charged
     @amount = set_cart.total_cents.to_i
+  end
+
+  def reduce_stock
+    set_charge.purchases.each do |purchase|
+      purchase.plant.number_of_clippings -= purchase.quantity_purchased
+      purchase.plant.save
+    end
   end
 
   def order_value

--- a/app/javascript/controllers/purchase_controls_controller.js
+++ b/app/javascript/controllers/purchase_controls_controller.js
@@ -1,18 +1,24 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = [ "counter", "price", "price_per" ]
+  static targets = [ "counter", "price", "price_per", "num_available" ]
 
   #updateNumbers = (count) => {
-    const cost = this.price_perTarget.dataset.costper * count
-    this.priceTarget.value = `Pay ${cost.toFixed(2)}`
+    const cost = this.price_perTarget.dataset.costper * count;
+    this.priceTarget.value = `Pay ${cost.toFixed(2)}`;
+  }
+
+  #maxNumbers = () => {
+    const num = this.num_availableTarget.dataset.numavailable;
+    return num;
   }
 
   increment(event) {
-    let offsetValue = Number(event.path[0].dataset.offset)
-    if ( (Number(this.counterTarget.value) > 1 && offsetValue == -1) || (Number(this.counterTarget.value) < 10 && offsetValue == 1) ) {
-      this.counterTarget.value = Number(this.counterTarget.value) + offsetValue
-      this.#updateNumbers(this.counterTarget.value)
+    let offsetValue = Number(event.path[0].dataset.offset);
+    if ( (Number(this.counterTarget.value) > 1 && offsetValue == -1) || (Number(this.counterTarget.value) < this.#maxNumbers() && offsetValue == 1) ) {
+      this.counterTarget.value = Number(this.counterTarget.value) + offsetValue;
+      this.#updateNumbers(this.counterTarget.value);
+
     }
   }
 

--- a/app/views/plants/_details_card.html.erb
+++ b/app/views/plants/_details_card.html.erb
@@ -1,4 +1,4 @@
-<div class="details-card-body">
+<div class="details-card-body" data-controller='purchase-controls'>
   <div class="seller-details">
     <p class='seller'>Posted by: <%= plant.user.first_name %></p>
     <p>Rating: </p>
@@ -12,10 +12,10 @@
   </div>
   <hr>
   <div class="purchase-option">
-    <p>Available cuttings: <%= plant.number_of_clippings %></p>
+    <p data-purchase-controls-target="num_available" data-numAvailable="<%= plant.number_of_clippings %>" >Available cuttings: <%= plant.number_of_clippings %></p>
   </div>
 
-  <div class="form-container" data-controller='purchase-controls'>
+  <div class="form-container">
     <div class="header">
       <div class="header-row">
         <div class="big-bold" id="price" data-purchase-controls-target="price_per" data-costPer="<%= plant.price_per_clipping %>">

--- a/app/views/plants/_purchase_form.html.erb
+++ b/app/views/plants/_purchase_form.html.erb
@@ -5,7 +5,6 @@
         <div class="actions">
           <a id="minus" data-action="purchase-controls#increment" class="btn round-bordered incrementer minus" data-offset="-1">-</a>
           <div class='neg-margin'>
-            <%# <input data-purchase-controls-target="counter" data-count="1" id='form-number' type="number" value='1'> %>
             <%= f.input :quantity_purchased, id:'form-number', label: false, input_html: { data: { purchase_controls_target: 'counter' }, class: "form-number", value:'1' }, data_count:"1" %>
           </div>
           <a id="plus" data-action="purchase-controls#increment" class="btn round-bordered incrementer" data-offset="1">+</a>


### PR DESCRIPTION
Updated JS so that you can only increment the number of plants to add to cart up to the number of clippings available.
Purchasing clippings now reduces the total number available in the store